### PR TITLE
Add note that appended loadouts are from ImproveTalentLoadouts

### DIFF
--- a/ImprovedTalentLoadouts.lua
+++ b/ImprovedTalentLoadouts.lua
@@ -1589,6 +1589,10 @@ function TalentLoadouts:InitializeHooks()
         if customLoadouts and SimcEditBox then
            local hooked = true
            local text = SimcEditBox:GetText()
+
+           local outputHeader = "\n\n# From ImprovedTalentLoadouts\n#"
+           customLoadouts = outputHeader .. customLoadouts
+
            SimcEditBox:SetCursorPosition(SimcEditBox:GetNumLetters())
            SimcEditBox:HighlightText(0,0)
            SimcEditBox:Insert(customLoadouts)


### PR DESCRIPTION
This text makes it a little clearer that the additional output is coming from this addon and not directly from the SimulationCraft addon.

I've been seeing a few reports of confusion because folks are pulling input from the game but Raidbots will warn since the checksum doesn't match. Hopefully this will make it a bit clearer where the changes are coming from.