### PR TITLE
Extend sort loadouts by name option to sort loadouts within categories

### DIFF
--- a/ImprovedTalentLoadouts.lua
+++ b/ImprovedTalentLoadouts.lua
@@ -2351,9 +2351,13 @@ local function LoadoutDropdownInitialize(_, level, menu, ...)
                 end
             end
 
-            for _, configID in ipairs(categoryInfo.loadouts) do
-                local configInfo = TalentLoadouts.globalDB.configIDs[currentSpecID][configID]
-                if configInfo and not configInfo.default then
+            local categoryLoadouts = {}
+            for _, cID in ipairs(categoryInfo.loadouts) do
+                table.insert(categoryLoadouts, cID, true)
+            end
+
+            for configID, configInfo in iterateLoadouts() do
+                if categoryLoadouts[configID] ~= nil and configInfo and not configInfo.default then
                     local color = configInfo.fake and "|cFF33ff96" or "|cFFFFD100"
                     LibDD:UIDropDownMenu_AddButton(
                         {


### PR DESCRIPTION
The sort loadouts by name option only sorts the loadouts found at the root level/level 1 of the ITL menu. By using the loadout iterator in the category section of the dropdown initialization and filtering to just the category's loadouts, the sort loadouts by name option will cover these sub menus as well.

---

View with sorting option disabled
![image](https://github.com/Lardeck/ImprovedTalentLoadouts/assets/17879923/3cd93b36-d4c5-4693-a89f-41718f34bce0)

Current behaviour with sorting option enabled
![image](https://github.com/Lardeck/ImprovedTalentLoadouts/assets/17879923/8efaadd0-e7b6-4133-8ce9-ab3715122660)

Behaviour with sorting option enabled and changes implemented
![image](https://github.com/Lardeck/ImprovedTalentLoadouts/assets/17879923/73fb1d59-c78d-4cd7-b407-bdaf08b7cd75)
