### PR TITLE
add Addon Category

### DIFF
--- a/ImprovedTalentLoadouts.toc
+++ b/ImprovedTalentLoadouts.toc
@@ -4,6 +4,7 @@
 ## SavedVariables: TalentLoadoutProfilesDB, ImprovedTalentLoadoutsDB
 ## OptionalDeps: Simulationcraft
 ## X-Curse-Project-ID: 822393
+## Category: User Interface
 
 Libs\TaintLess\TaintLess.xml
 Libs\LibStub\LibStub.lua


### PR DESCRIPTION
This will add the addon to the category displayed on the addon overview:
<img width="350" height="358" alt="{A7B1E846-8A22-41DB-A203-EA5EE61F314C}" src="https://github.com/user-attachments/assets/72c71ed6-e4f3-4b03-a5a8-2cedb39b5713" />

There are some default values for these categories, feel free to suggest a different one:
https://warcraft.wiki.gg/wiki/Addon_Categories#User_Interface